### PR TITLE
Better readability for Docker image build  workflow

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -5,22 +5,35 @@ on:
     branches: [ "main" ]
 
 jobs:
+  define-matrix:
+    runs-on: self-hosted
+
+    outputs:
+      dirs: ${{ steps.dirs.outputs.dirs }}
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: 🔍 Find dirs
+        id: dirs
+        run: |
+          python .github/workflows/matrixbuilder.py >> "$GITHUB_OUTPUT"
 
   build:
+    needs: define-matrix
     strategy:
       matrix:
-        dir: [unihub, unihubsingle, base, base/conda, base/conda/pytorch, base/conda/pytorch-gpu, base/engineering]
+        dir: ${{ fromJSON(needs.define-matrix.outputs.dirs) }}
 
     runs-on: self-hosted
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: 🛠 Build Docker image
-      run: cd ${{ matrix.dir}} && make build
+      - name: 🛠 Build Docker image
+        run: cd ${{ matrix.dir}} && make build
 
-    - name: 🚀 Push Docker image
-      run: cd ${{ matrix.dir}} && make push
+      - name: 🚀 Push Docker image
+        run: cd ${{ matrix.dir}} && make push
 
-    - name: 🔖 Tag Docker image
-      run: cd ${{ matrix.dir}} && make tag
+      - name: 🔖 Tag Docker image
+        run: cd ${{ matrix.dir}} && make tag

--- a/.github/workflows/matrixbuilder.py
+++ b/.github/workflows/matrixbuilder.py
@@ -1,0 +1,22 @@
+import os
+import json
+
+
+fixed = [
+    'ldapproxy/docker',
+    'ldapsyncservice/docker',
+    'web/docker',
+    'unihub',
+    'unihubsingle',
+]
+folders = []
+
+# walks inside `base` folder and finds all dir
+# names with a `Makefile` inside
+for root, dirs, files in os.walk('./base'):
+    if 'Makefile' in files:
+        folders.append(root)
+
+folders += fixed
+
+print(f'dirs={json.dumps(folders)}')


### PR DESCRIPTION
Added a matrix strategy to build containers images. Matrix is used to specify wich folder to cd into and run `make` command. This will improve the output's readability.