### PR TITLE
🐛 (base/conda/hydraulics): fix qgis sources

### DIFF
--- a/base/conda/hydraulics/Dockerfile
+++ b/base/conda/hydraulics/Dockerfile
@@ -16,6 +16,7 @@ RUN apt update && \
     apt update
 
 RUN apt install -y qgis qgis-plugin-grass python3-qgis grass grass-doc openmpi-bin && \
+    conda install conda-forge::qgis && \
     flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo && \
     flatpak install -y flathub org.cloudcompare.CloudCompare && \
     mkdir swatplus && \


### PR DESCRIPTION
Refactored Dockerfile for the new ubuntu base (instead old debian).
Fixed the "Missing qgis module" error when opening QGIS by installing QGIS via conda-forge.
