### PR TITLE
♻️ (Makefile): refactor Makefile code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,6 @@
-DIRS=unihub \
-unihubsingle \
-unihubbackup \
-base \
-base/conda \
-base/conda/pytorch \
-base/conda/pytorch-gpu \
-base/engineering
+FIRSTDIRS=./unihub ./unihubsingle ./unihubbackup ./base
+ALLDIRS:=$(shell find . -mindepth 2 -name Makefile | xargs dirname)
+DIRS:=$(FIRSTDIRS) $(filter-out $(FIRSTDIRS), $(ALLDIRS))
 
 .PHONY: all
 all: build push tag


### PR DESCRIPTION
Updated the Makefile part that finds the images to build. Now are automatically detected and are sorted like the github action: unihub, unihubsingle and unihubbackup first and then all the images inside 'base' and the submodule images.