### PR TITLE
🐛 (Makefile): fix branch naming issue

### DIFF
--- a/ImageMakefile
+++ b/ImageMakefile
@@ -1,6 +1,6 @@
 include buildinfo.mk
 
-BRANCH:=$(shell git branch --show-current)
+BRANCH:=$(shell git branch --show-current|sed -r 's/\//-/g')
 
 .PHONY: all 
 all: check build push quay


### PR DESCRIPTION
Fixed an issue with branch naming causing errors while building images. This happens because `/` cannot be in branch names: branch name is used for docker image tagging and a `/` cannot be inside a docker tag. This issue is caused mainly by dependabot: dependabot created branches are named: `dependabo/submodule/version`.
This issue is fixed by replacing `/` with `-` while getting the actual branch name inside the `Makefile`.