### PR TITLE
✨ (base): add ristretto image viewer

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -3,7 +3,7 @@ FROM harbor1.fisgeo.unipg.it/uninuvola/unihubsingle:main
 USER root
 
 RUN apt update && \
-    apt install -y zip unzip unrar-free openssh-client htop procps nano less tmux screen vim curl git gfortran rsync
+    apt install -y zip unzip unrar-free openssh-client htop procps nano less tmux screen vim curl git gfortran rsync ristretto
 
 # Firefox
 RUN install -d -m 0755 /etc/apt/keyrings && \


### PR DESCRIPTION
Added [ristretto](https://docs.xfce.org/apps/ristretto/start) image viewer to Base UniNuvola image in order to let all other image inherit this software.
Ristretto is the XFCE default image viewer.

We are missing an image viewer that is quite useful when working with images.
Some users request this feature.